### PR TITLE
feat: Integrate Raydium DEX and add multi-chain support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aave/core": "^0.1.0",
+        "@solana/web3.js": "^1.98.4",
         "ethers": "^5.7.2",
         "hardhat": "^2.12.0"
       },
@@ -532,6 +533,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2413,6 +2423,139 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2456,6 +2599,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -2517,7 +2669,6 @@
       "version": "20.19.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2536,6 +2687,21 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.34",
@@ -2821,6 +2987,18 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3089,6 +3267,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
@@ -3122,6 +3329,17 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
       "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
       "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -3238,6 +3456,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3246,6 +3473,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3576,6 +3827,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3717,6 +3980,21 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/escalade": {
@@ -3990,6 +4268,12 @@
         "@ethersproject/wordlists": "5.8.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4038,6 +4322,14 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4089,6 +4381,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -4661,6 +4959,15 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4672,6 +4979,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4906,6 +5233,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4975,6 +5311,65 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.2.0.tgz",
+      "integrity": "sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest": {
@@ -5642,6 +6037,12 @@
         "node": ">=7.10.1"
       }
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6194,6 +6595,26 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -6795,6 +7216,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.2.0.tgz",
+      "integrity": "sha512-DS/XHdPxplQTtNRKiBCRWGBJfjOk56W7fyFUpiYi9fSTWTzoEMbUkn3J4gB0IMniIEVeAGR1/rzFQogzD5MxvQ==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^8.3.4",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^8.3.2",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7035,6 +7488,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7116,6 +7584,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7180,6 +7657,11 @@
         "node": "*"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7242,6 +7724,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
@@ -7372,7 +7860,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -7413,7 +7900,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -7503,6 +7989,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7604,6 +8106,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@aave/core": "^0.1.0",
+    "@solana/web3.js": "^1.98.4",
     "ethers": "^5.7.2",
     "hardhat": "^2.12.0"
   },

--- a/src/dex/__tests__/DEXRegistry.test.ts
+++ b/src/dex/__tests__/DEXRegistry.test.ts
@@ -1,0 +1,68 @@
+import DEXRegistry from '../core/DEXRegistry';
+import { ethers } from 'ethers';
+import { Connection } from '@solana/web3.js';
+
+const getAccountInfoMock = jest.fn().mockResolvedValue({
+    executable: true,
+});
+
+jest.mock('@solana/web3.js', () => {
+    const originalWeb3 = jest.requireActual('@solana/web3.js');
+    return {
+        ...originalWeb3,
+        Connection: jest.fn().mockImplementation(() => ({
+            getAccountInfo: getAccountInfoMock,
+        })),
+    };
+});
+
+describe('DEXRegistry', () => {
+  let registry: DEXRegistry;
+  let getCodeMock: jest.Mock;
+
+  beforeEach(() => {
+    getCodeMock = jest.fn().mockResolvedValue('0x123');
+    const mockProvider = {
+        getCode: getCodeMock,
+    };
+    jest.spyOn(ethers.providers, 'JsonRpcProvider').mockImplementation(() => mockProvider as any);
+
+    (Connection as jest.Mock).mockClear();
+    getAccountInfoMock.mockClear();
+
+    registry = new DEXRegistry();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should initialize with the correct number of DEXes', () => {
+    const allDEXes = registry.getAllDEXes();
+    expect(allDEXes.length).toBe(7);
+  });
+
+  it('should include Raydium in the list of DEXes', () => {
+    const raydium = registry.getDEX('Raydium');
+    expect(raydium).toBeDefined();
+    expect(raydium?.protocol).toBe('Raydium');
+  });
+
+  it('should return the correct DEXes for the Solana network', () => {
+    const solanaDEXes = registry.getDEXesByNetwork('mainnet-beta');
+    expect(solanaDEXes.length).toBe(1);
+    expect(solanaDEXes[0].name).toBe('Raydium');
+  });
+
+  it('should return the correct DEXes for the EVM network', () => {
+    const evmDEXes = registry.getDEXesByNetwork('1');
+    expect(evmDEXes.length).toBe(6);
+  });
+
+  it('should validate all DEXes successfully', async () => {
+    const isValid = await registry.validateDEXes();
+    expect(isValid).toBe(true);
+    expect(getCodeMock).toHaveBeenCalledTimes(6);
+    expect(getAccountInfoMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/dex/core/DEXRegistry.ts
+++ b/src/dex/core/DEXRegistry.ts
@@ -1,5 +1,13 @@
 import { ethers } from 'ethers';
-import { DEXConfig } from '../types';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { DEXConfig, ChainType } from '../types';
+
+const getSolanaRpcEndpoint = (network: string): string => {
+    if (network === 'mainnet-beta') {
+        return 'https://api.mainnet-beta.solana.com';
+    }
+    return 'https://api.devnet.solana.com';
+};
 
 export class DEXRegistry {
     private readonly timestamp: string = new Date().toISOString();
@@ -15,7 +23,8 @@ export class DEXRegistry {
         this.addDEX({
             name: 'Uniswap V3',
             protocol: 'UniswapV3',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
             factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
             initCodeHash: '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',
@@ -28,7 +37,8 @@ export class DEXRegistry {
         this.addDEX({
             name: 'Curve',
             protocol: 'Curve',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0x99a58482BD75cbab83b27EC03CA68fF489b5788f',
             factory: '0xB9fC157394Af804a3578134A6585C0dc9cc990d4',
             initCodeHash: '0x0f345e9d36a98a0d18fb9d8724c163499968dd2f130657141ba7a3557fd7854c',
@@ -41,7 +51,8 @@ export class DEXRegistry {
         this.addDEX({
             name: 'SushiSwap',
             protocol: 'SushiSwap',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F',
             factory: '0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac',
             initCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
@@ -54,7 +65,8 @@ export class DEXRegistry {
         this.addDEX({
             name: 'Balancer',
             protocol: 'Balancer',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
             factory: '0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9',
             initCodeHash: '0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f',
@@ -67,7 +79,8 @@ export class DEXRegistry {
         this.addDEX({
             name: '1inch',
             protocol: '1inch',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0x1111111254fb6c44bAC0beD2854e76F90643097d',
             factory: '0x1111111254fb6c44bAC0beD2854e76F90643097d',
             initCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
@@ -80,13 +93,26 @@ export class DEXRegistry {
         this.addDEX({
             name: 'PancakeSwap V3',
             protocol: 'PancakeSwapV3',
-            chainId: 1,
+            chainType: 'EVM',
+            network: '1',
             router: '0x1b81D678ffb9C0263b24A97847620C99d213eB14',
             factory: '0x0bfbcf9fa4f9c56b0f40a671ad40e0805a091865',
             initCodeHash: '0x6100b2845c25e831c513e6183a6a96a33753c156d11d13f0156ba906a6408a2b',
             priority: 6,
             liquidityThreshold: BigInt(ethers.utils.parseEther('20000').toString()),
             gasEstimate: 170000
+        });
+
+        // Initialize Raydium
+        this.addDEX({
+            name: 'Raydium',
+            protocol: 'Raydium',
+            chainType: 'Solana',
+            network: 'mainnet-beta',
+            router: 'routeUGWgWzqBWFcrCfv8tritsqukccJPu3q5GPP3xS',
+            factory: '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8',
+            priority: 7,
+            liquidityThreshold: BigInt(10000)
         });
     }
 
@@ -107,21 +133,27 @@ export class DEXRegistry {
         return this.getAllDEXes().slice(0, count);
     }
 
-    getDEXesByChain(chainId: number): DEXConfig[] {
-        return this.getAllDEXes().filter(dex => dex.chainId === chainId);
+    getDEXesByNetwork(network: string): DEXConfig[] {
+        return this.getAllDEXes().filter(dex => dex.network === network);
     }
 
     async validateDEXes(): Promise<boolean> {
         for (const dex of this.getAllDEXes()) {
             try {
-                const provider = new ethers.providers.JsonRpcProvider();
-                
-                // Check if contracts exist
-                const code = await provider.getCode(dex.router);
-                const isValid = code !== '0x';
-                
-                if (!isValid) {
-                    return false;
+                if (dex.chainType === 'EVM') {
+                    const provider = new ethers.providers.JsonRpcProvider();
+                    const code = await provider.getCode(dex.router);
+                    if (code === '0x') {
+                        return false;
+                    }
+                } else if (dex.chainType === 'Solana') {
+                    const endpoint = getSolanaRpcEndpoint(dex.network);
+                    const connection = new Connection(endpoint);
+                    const publicKey = new PublicKey(dex.router);
+                    const accountInfo = await connection.getAccountInfo(publicKey);
+                    if (!accountInfo || !accountInfo.executable) {
+                        return false;
+                    }
                 }
             } catch (error) {
                 return false;

--- a/src/dex/types.ts
+++ b/src/dex/types.ts
@@ -9,16 +9,19 @@ import { EmotionalContext } from '../consciousness/types/memory';
 /**
  * DEX configuration interface
  */
+export type ChainType = 'EVM' | 'Solana';
+
 export interface DEXConfig {
   name: string;
   protocol: string;
-  chainId: number;
+  chainType: ChainType;
+  network: string; // e.g., '1' for EVM, 'mainnet-beta' for Solana
   router: string;
   factory: string;
-  initCodeHash: string;
+  initCodeHash?: string;
   priority: number;
   liquidityThreshold: bigint;
-  gasEstimate: number;
+  gasEstimate?: number;
 }
 
 /**


### PR DESCRIPTION
This commit introduces support for non-EVM chains, specifically Solana, and integrates the Raydium DEX.

- Refactored `DEXConfig` to be chain-agnostic by introducing a `chainType` and `network` field.
- Updated `DEXRegistry` to handle both EVM and Solana chains, including validation logic.
- Added the Raydium DEX to the registry.
- Created a new test suite for `DEXRegistry` to ensure the multi-chain support is working correctly.