### PR TITLE
feat: Add Self-Funder arbitrage test script and contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Optional: Enable debug logging
 # DEBUG=true
+
+# Hardhat Configuration
+# Your private key for the Base network
+# BASE_PRIVATE_KEY=your_private_key_here
+# Optional: Override the default Base RPC URL
+# BASE_RPC_URL=https://your_base_rpc_url

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,21 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomiclabs/hardhat-waffle";
+import "@nomiclabs/hardhat-ethers";
+require('dotenv').config();
+
+console.log("BASE_PRIVATE_KEY:", process.env.BASE_PRIVATE_KEY);
+
+const config: HardhatUserConfig = {
+  paths: {
+    sources: "./src/arbitrage",
+  },
+  solidity: "0.8.20",
+  networks: {
+    base: {
+      url: process.env.BASE_RPC_URL || "https://mainnet.base.org",
+      accounts: process.env.BASE_PRIVATE_KEY ? [process.env.BASE_PRIVATE_KEY] : [],
+    },
+  },
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@aave/core": "^0.1.0",
-        "@solana/web3.js": "^1.98.4"
+        "@openzeppelin/contracts": "^5.4.0",
+        "@solana/web3.js": "^1.98.4",
+        "dotenv": "^17.2.3"
       },
       "devDependencies": {
         "@aave/core-v3": "^1.19.3",
@@ -60,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.19.3.tgz",
       "integrity": "sha512-Xr7+VcoU5b4mPwM4IUCnskw3lciwrnL4Xloyad8GOddYeixnri2lZYobNmErm1LwE50vqjI0O+9QGNKY2TDkeQ==",
       "dev": true,
+      "license": "BUSL-1.1",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -117,6 +120,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -639,7 +643,6 @@
       "integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
       "deprecated": "Please use @ensdomains/ens-contracts",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bluebird": "^3.5.2",
         "eth-ens-namehash": "^2.0.8",
@@ -653,7 +656,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -663,7 +665,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -673,7 +674,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -685,7 +685,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -695,7 +694,6 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^2.1.0",
@@ -708,15 +706,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@ensdomains/ens/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -729,7 +725,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "dev": true,
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -740,7 +735,6 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -753,7 +747,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -763,7 +756,6 @@
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
       "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fs-extra": "^0.30.0",
         "memorystream": "^0.3.1",
@@ -780,7 +772,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -795,7 +786,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -808,7 +798,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -821,15 +810,13 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
       "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@ensdomains/ens/node_modules/yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cliui": "^3.2.0",
         "decamelize": "^1.1.1",
@@ -852,7 +839,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"
@@ -947,7 +933,6 @@
       "resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-4.0.10.tgz",
       "integrity": "sha512-X5RepE7Dn8KQLFO7HHAAe+KeGaX/by14hn90wePGBhzL54tq4Y8JscZFu+/LCwCl6TnkAAy5ebiMoqJ37sFtWw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereum-waffle/provider": "4.0.5",
         "debug": "^4.3.4",
@@ -965,7 +950,6 @@
       "resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-4.0.3.tgz",
       "integrity": "sha512-5x5U52tSvEVJS6dpCeXXKvRKyf8GICDwiTwUvGD3/WD+DpvgvaoHOL82XqpTSUHgV3bBq6ma5/8gKUJUIAnJCw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@resolver-engine/imports": "^0.3.3",
         "@resolver-engine/imports-fs": "^0.3.3",
@@ -989,7 +973,6 @@
       "resolved": "https://registry.npmjs.org/@ethereum-waffle/ens/-/ens-4.0.3.tgz",
       "integrity": "sha512-PVLcdnTbaTfCrfSOrvtlA9Fih73EeDvFS28JQnT5M5P4JMplqmchhcZB1yg/fCtx4cvgHlZXa0+rOCAk2Jk0Jw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0"
       },
@@ -1004,7 +987,6 @@
       "resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-4.0.4.tgz",
       "integrity": "sha512-LwEj5SIuEe9/gnrXgtqIkWbk2g15imM/qcJcxpLyAkOj981tQxXmtV4XmQMZsdedEsZ/D/rbUAOtZbgwqgUwQA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0"
       },
@@ -1017,7 +999,6 @@
       "resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-4.0.5.tgz",
       "integrity": "sha512-40uzfyzcrPh+Gbdzv89JJTMBlZwzya1YLDyim8mVbEqYLP5VRYWoGp0JMyaizgV3hMoUFRqJKVmIUw4v7r3hYw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereum-waffle/ens": "4.0.3",
         "@ganache/ethereum-options": "0.1.4",
@@ -1036,7 +1017,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.3.tgz",
       "integrity": "sha512-CegDeryc2DVKnDkg5COQrE0bJfw/p0v3GBk2W5/Dj5dOVfEmb50Ux0GLnSPypooLnfqjwFaorGuT9FokWB3GRg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^2.6.5",
         "@ethereumjs/tx": "^3.5.2",
@@ -1049,7 +1029,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
       "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.5"
@@ -1060,7 +1039,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.2.tgz",
       "integrity": "sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^2.6.4",
         "ethereumjs-util": "^7.1.5"
@@ -1071,7 +1049,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -1088,7 +1065,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.3.tgz",
       "integrity": "sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/block": "^3.6.2",
         "@ethereumjs/common": "^2.6.4",
@@ -1105,7 +1081,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
       "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.5"
@@ -1116,7 +1091,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -1133,7 +1107,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.0.tgz",
       "integrity": "sha512-Cq2qS0FTu6O2VU1sgg+WyU9Ps0M6j/BEMHN+hRaECXCV/r0aI78u4N6p52QW/BDVhwWZpCdrvG8X7NJdzlpNUA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.3"
@@ -1144,7 +1117,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
       "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/block": "^3.5.0",
         "@types/levelup": "^4.3.0",
@@ -1158,7 +1130,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
       "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -1171,7 +1142,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.4.0.tgz",
       "integrity": "sha512-WWUwg1PdjHKZZxPPo274ZuPsJCWV3SqATrEKQP1n2DrVYVP1aZIYpo/mFaA0BDoE0tIQmBeimRCEA0Lgil+yYw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^2.6.0",
         "ethereumjs-util": "^7.1.3"
@@ -1182,7 +1152,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
       "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^2.0.0",
@@ -1197,7 +1166,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
       "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -1210,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1223,7 +1190,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
       "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
@@ -1236,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.6.0.tgz",
       "integrity": "sha512-J2m/OgjjiGdWF2P9bj/4LnZQ1zRoZhY8mRNVw/N3tXliGI8ai1sI1mlDPkLpeUUM4vq54gH6n0ZlSpz8U/qlYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/block": "^3.6.0",
         "@ethereumjs/blockchain": "^5.5.0",
@@ -1257,7 +1222,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1266,8 +1230,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@ethersproject/abi": {
       "version": "5.8.0",
@@ -1285,6 +1248,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -1709,6 +1673,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/abstract-signer": "^5.8.0",
@@ -2014,7 +1979,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/ethereum-address/-/ethereum-address-0.1.4.tgz",
       "integrity": "sha512-sTkU0M9z2nZUzDeHRzzGlW724xhMLXo2LeX1hixbnjHWY1Zg1hkqORywVfl+g5uOO8ht8T0v+34IxNxAhmWlbw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ganache/utils": "0.1.4"
       }
@@ -2024,7 +1988,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/ethereum-options/-/ethereum-options-0.1.4.tgz",
       "integrity": "sha512-i4l46taoK2yC41FPkcoDlEVoqHS52wcbHPqJtYETRWqpOaoj9hAg/EJIHLb1t6Nhva2CdTO84bG+qlzlTxjAHw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ganache/ethereum-address": "0.1.4",
         "@ganache/ethereum-utils": "0.1.4",
@@ -2039,7 +2002,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/ethereum-utils/-/ethereum-utils-0.1.4.tgz",
       "integrity": "sha512-FKXF3zcdDrIoCqovJmHLKZLrJ43234Em2sde/3urUT/10gSgnwlpFmrv2LUMAmSbX3lgZhW/aSs8krGhDevDAg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "2.6.0",
         "@ethereumjs/tx": "3.4.0",
@@ -2057,7 +2019,6 @@
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
       "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2070,7 +2031,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/options/-/options-0.1.4.tgz",
       "integrity": "sha512-zAe/craqNuPz512XQY33MOAG6Si1Xp0hCvfzkBfj2qkuPcbJCq6W/eQ5MB6SbXHrICsHrZOaelyqjuhSEmjXRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ganache/utils": "0.1.4",
         "bip39": "3.0.4",
@@ -2082,7 +2042,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/rlp/-/rlp-0.1.4.tgz",
       "integrity": "sha512-Do3D1H6JmhikB+6rHviGqkrNywou/liVeFiKIpOBLynIpvZhRCgn3SEDxyy/JovcaozTo/BynHumfs5R085MFQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ganache/utils": "0.1.4",
         "rlp": "2.2.6"
@@ -2093,7 +2052,6 @@
       "resolved": "https://registry.npmjs.org/@ganache/utils/-/utils-0.1.4.tgz",
       "integrity": "sha512-oatUueU3XuXbUbUlkyxeLLH3LzFZ4y5aSkNbx6tjSIhVTPeh+AuBKYt4eQ73FFcTB3nj/gZoslgAh5CN7O369w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "emittery": "0.10.0",
         "keccak": "3.0.1",
@@ -2108,7 +2066,6 @@
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
       "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3027,6 +2984,7 @@
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz",
       "integrity": "sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "ethers": "^5.0.0",
         "hardhat": "^2.0.0"
@@ -3045,12 +3003,17 @@
         "hardhat": "^2.0.0"
       }
     },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz",
+      "integrity": "sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==",
+      "license": "MIT"
+    },
     "node_modules/@resolver-engine/core": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.3.3.tgz",
       "integrity": "sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "is-url": "^1.2.4",
@@ -3062,7 +3025,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3072,7 +3034,6 @@
       "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.3.3.tgz",
       "integrity": "sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@resolver-engine/core": "^0.3.3",
         "debug": "^3.1.0"
@@ -3083,7 +3044,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3093,7 +3053,6 @@
       "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.3.3.tgz",
       "integrity": "sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@resolver-engine/core": "^0.3.3",
         "debug": "^3.1.0",
@@ -3107,7 +3066,6 @@
       "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.3.3.tgz",
       "integrity": "sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@resolver-engine/fs": "^0.3.3",
         "@resolver-engine/imports": "^0.3.3",
@@ -3119,7 +3077,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3129,7 +3086,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3162,7 +3118,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
       "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.4.0",
         "@noble/hashes": "~1.4.0",
@@ -3177,7 +3132,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
       "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -3190,7 +3144,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -3203,7 +3156,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
       "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
@@ -3217,7 +3169,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -3480,7 +3431,7 @@
       "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
+      "optional": true,
       "dependencies": {
         "node-gyp-build": "4.3.0"
       },
@@ -3517,7 +3468,6 @@
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-10.2.1.tgz",
       "integrity": "sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "ts-essentials": "^7.0.1"
@@ -3534,8 +3484,7 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.5.tgz",
       "integrity": "sha512-/2B0nQF4UdupuxeKTJA2+Rj1D+uDemo6P4kMwKCpbfpnzeVaWSELTsAw4Lxn3VJD6APtRrZOCuYo+4nHUQfTfg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.4",
@@ -3605,7 +3554,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -3624,8 +3572,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/events": {
       "version": "3.0.3",
@@ -3692,15 +3639,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.2.tgz",
       "integrity": "sha512-gyZHbcQ2X5hNXf/9KS2qGEmgDe9EN2WDM3rJ5Ele467C0nA1sLhtmv1bZiPMDYfAYCfPWft0uQIaTvXbASSTRA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/levelup": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
       "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/abstract-leveldown": "*",
         "@types/level-errors": "*",
@@ -3718,7 +3663,6 @@
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3728,6 +3672,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3737,7 +3682,6 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -3756,8 +3700,7 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.7",
@@ -3780,7 +3723,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
       "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -3800,8 +3742,7 @@
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
       "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3884,6 +3825,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -4093,7 +4035,6 @@
       "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "immediate": "^3.2.3",
@@ -4124,7 +4065,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4135,7 +4075,6 @@
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.2"
       },
@@ -4149,6 +4088,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4340,7 +4280,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4360,7 +4299,6 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -4370,7 +4308,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -4380,7 +4317,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4407,8 +4343,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4430,7 +4365,6 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4439,8 +4373,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4619,7 +4552,6 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -4628,8 +4560,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/bech32": {
       "version": "1.1.4",
@@ -4652,7 +4583,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4674,7 +4604,6 @@
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
       "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -4686,8 +4615,7 @@
       "version": "11.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
@@ -4699,8 +4627,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "5.2.2",
@@ -4807,6 +4734,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4900,7 +4828,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
       "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }
@@ -5006,8 +4933,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/catering": {
       "version": "2.1.1",
@@ -5175,7 +5101,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5212,7 +5137,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5231,7 +5155,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -5247,7 +5170,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
       "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.2",
         "chalk": "^2.4.2",
@@ -5263,7 +5185,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -5276,7 +5197,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5286,7 +5206,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5301,7 +5220,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -5310,15 +5228,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/command-line-usage/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5328,7 +5244,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5338,7 +5253,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -5351,7 +5265,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5361,7 +5274,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5395,7 +5307,6 @@
       "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -5494,7 +5405,6 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -5552,7 +5462,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5580,7 +5489,6 @@
       "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "abstract-leveldown": "~6.2.1",
         "inherits": "^2.0.3"
@@ -5595,7 +5503,6 @@
       "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "immediate": "^3.2.3",
@@ -5626,7 +5533,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5637,7 +5543,6 @@
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.2"
       },
@@ -5679,7 +5584,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5748,6 +5652,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5767,7 +5683,6 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -5829,7 +5744,6 @@
       "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "abstract-leveldown": "^6.2.1",
         "inherits": "^2.0.3",
@@ -5867,7 +5781,6 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -5920,7 +5833,6 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -5976,6 +5888,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6152,7 +6065,6 @@
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
       "integrity": "sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "idna-uts46-hx": "^2.3.1",
         "js-sha3": "^0.5.7"
@@ -6162,15 +6074,13 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.2.0.tgz",
       "integrity": "sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.4.0"
       }
@@ -6268,7 +6178,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz",
       "integrity": "sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -6295,6 +6204,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -6333,7 +6243,6 @@
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -6347,8 +6256,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -6443,8 +6351,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -6453,8 +6360,7 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -6572,7 +6478,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -6668,7 +6573,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6678,7 +6582,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6764,7 +6667,6 @@
       ],
       "dev": true,
       "hasShrinkwrap": true,
-      "peer": true,
       "dependencies": {
         "@trufflesuite/bigint-buffer": "1.1.10",
         "@types/bn.js": "^5.1.0",
@@ -6792,7 +6694,6 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "4.4.0"
       },
@@ -6807,7 +6708,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -6821,7 +6721,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6832,8 +6731,7 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/@types/node": {
       "version": "17.0.0",
@@ -6841,8 +6739,7 @@
       "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/@types/seedrandom": {
       "version": "3.0.1",
@@ -6850,8 +6747,7 @@
       "integrity": "sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/base64-js": {
       "version": "1.5.1",
@@ -6873,8 +6769,7 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/brorand": {
       "version": "1.1.0",
@@ -6882,8 +6777,7 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/buffer": {
       "version": "6.0.3",
@@ -6906,7 +6800,6 @@
       ],
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -6917,9 +6810,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       }
@@ -6931,7 +6822,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "queue-tick": "^1.0.0"
       },
@@ -6946,7 +6836,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6963,8 +6852,7 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/emittery": {
       "version": "0.10.0",
@@ -6973,7 +6861,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6988,7 +6875,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -7001,7 +6887,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -7028,8 +6913,7 @@
         }
       ],
       "inBundle": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ganache/node_modules/inherits": {
       "version": "2.0.4",
@@ -7037,8 +6921,7 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ganache/node_modules/is-buffer": {
       "version": "2.0.5",
@@ -7061,7 +6944,6 @@
       ],
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7074,7 +6956,6 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -7092,7 +6973,6 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abstract-leveldown": "^7.2.0",
         "napi-macros": "~2.0.0",
@@ -7109,7 +6989,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "catering": "^2.0.0",
@@ -7129,7 +7008,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "catering": "^2.1.0"
       },
@@ -7144,7 +7022,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7155,8 +7032,7 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ganache/node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -7164,8 +7040,7 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/napi-macros": {
       "version": "2.0.0",
@@ -7173,8 +7048,7 @@
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -7182,8 +7056,7 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/node-gyp-build": {
       "version": "4.3.0",
@@ -7192,7 +7065,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -7219,8 +7091,7 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/queue-tick": {
       "version": "1.0.0",
@@ -7228,8 +7099,7 @@
       "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/readable-stream": {
       "version": "3.6.0",
@@ -7238,7 +7108,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7268,8 +7137,7 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache/node_modules/secp256k1": {
       "version": "4.0.3",
@@ -7279,7 +7147,6 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
@@ -7296,7 +7163,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7306,9 +7172,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       }
@@ -7319,8 +7183,7 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7407,7 +7270,6 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -7528,6 +7390,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -7559,7 +7422,6 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7570,7 +7432,6 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -7584,6 +7445,7 @@
       "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.0.tgz",
       "integrity": "sha512-mNJFbVG479HwOzxiaLxobyvED2M1aEAuPPYhEo1+88yicMDSTrU2JIS7vV+V0GSNQKaDoiHCmV6bcKjiljT/dQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
@@ -8183,8 +8045,7 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8214,7 +8075,6 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -8274,7 +8134,6 @@
       "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
       "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "2.1.0"
       },
@@ -8316,8 +8175,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/immutable": {
       "version": "4.3.7",
@@ -8405,7 +8263,6 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8603,8 +8460,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -8622,15 +8478,13 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/isarray": {
       "version": "2.0.5",
@@ -8658,8 +8512,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8797,6 +8650,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9405,8 +9259,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -9426,7 +9279,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -9449,8 +9301,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9492,7 +9343,6 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -9551,7 +9401,6 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -9583,7 +9432,6 @@
       "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -9610,7 +9458,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -9622,7 +9469,6 @@
       "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9633,7 +9479,6 @@
       "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "errno": "~0.1.1"
       },
@@ -9646,7 +9491,6 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
       "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0",
@@ -9662,7 +9506,6 @@
       "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
       "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "level-packager": "^5.0.3",
         "memdown": "^5.0.0"
@@ -9677,7 +9520,6 @@
       "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "encoding-down": "^6.3.0",
         "levelup": "^4.3.2"
@@ -9713,7 +9555,6 @@
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
       "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.0",
@@ -9729,7 +9570,6 @@
       "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "deferred-leveldown": "~5.3.0",
         "level-errors": "~2.0.0",
@@ -9746,7 +9586,6 @@
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.2"
       },
@@ -9790,7 +9629,6 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -9807,7 +9645,6 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -9820,7 +9657,6 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
@@ -9854,15 +9690,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -9914,8 +9748,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -9985,7 +9818,6 @@
       "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
       "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "abstract-leveldown": "~6.2.1",
         "functional-red-black-tree": "~1.0.1",
@@ -10004,7 +9836,6 @@
       "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
       "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "immediate": "^3.2.3",
@@ -10035,7 +9866,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -10045,15 +9875,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
       "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/memdown/node_modules/level-supports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.2"
       },
@@ -10106,7 +9934,6 @@
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz",
       "integrity": "sha512-eHbf/BG6eGNsqqfbLED9rIqbsF4+sykEaBn6OLNs71tjclbMcMOk1tEPmJKcNcNCLkvbpY/lwyOlizWsqPNo8w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/levelup": "^4.3.0",
         "ethereumjs-util": "^7.1.4",
@@ -10121,7 +9948,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -10137,8 +9963,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
       "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10159,7 +9984,6 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -10172,15 +9996,13 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10190,7 +10012,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10247,7 +10068,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10470,7 +10290,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
       "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -10496,7 +10316,6 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -10509,7 +10328,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -10542,7 +10360,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10552,7 +10369,6 @@
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -10566,15 +10382,13 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10646,7 +10460,6 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -10756,8 +10569,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -10827,8 +10639,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10854,7 +10665,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10864,7 +10674,6 @@
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10874,7 +10683,6 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -11048,15 +10856,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -11069,7 +10875,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11079,7 +10884,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11173,7 +10977,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -11188,7 +10991,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -11202,7 +11004,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -11216,7 +11017,6 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
       },
@@ -11229,7 +11029,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -11270,7 +11069,6 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11281,7 +11079,6 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -11313,7 +11110,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -11328,7 +11124,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -11339,7 +11134,6 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
-      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -11359,7 +11153,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
       "integrity": "sha512-H7AkJWMobeskkttHyhTVtS0fxpFLjxhbfMa6Bk3wimP7sdPRGL3EyCg3sAQenFfAe+xQ+oAc85Nmtvq0ROM83Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11368,8 +11161,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -11637,15 +11429,13 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/semaphore-async-await": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
       "integrity": "sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.1"
       }
@@ -11676,8 +11466,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11874,7 +11663,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -11905,7 +11693,6 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -11915,15 +11702,13 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -11933,8 +11718,7 @@
       "version": "3.0.22",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -11948,7 +11732,6 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -11973,8 +11756,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -12057,8 +11839,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
       "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -12188,7 +11969,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
       "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -12204,7 +11984,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12214,7 +11993,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12252,8 +12030,7 @@
       "resolved": "https://registry.npmjs.org/testrpc/-/testrpc-0.0.1.tgz",
       "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
       "deprecated": "testrpc has been renamed to ganache-cli, please use this package from now on.",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
@@ -12327,7 +12104,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -12341,7 +12117,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12370,7 +12145,6 @@
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
       "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -12386,7 +12160,6 @@
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
       "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=3.7.0"
       }
@@ -12461,6 +12234,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12525,7 +12299,6 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -12612,7 +12385,6 @@
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12633,7 +12405,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12646,7 +12417,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -12659,7 +12429,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -12689,6 +12458,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12702,7 +12472,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12793,7 +12562,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -12806,15 +12574,13 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -12857,7 +12623,6 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -12871,7 +12636,6 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -12893,7 +12657,6 @@
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.4.tgz",
       "integrity": "sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "bn.js": "^5.2.1",
@@ -12913,7 +12676,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
       "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -12926,7 +12688,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -12939,7 +12700,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
       "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
@@ -12983,8 +12743,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
@@ -13012,7 +12771,6 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "window-size": "cli.js"
       },
@@ -13048,7 +12806,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
       "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -13062,7 +12819,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13117,6 +12873,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13138,7 +12895,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "dependencies": {
     "@aave/core": "^0.1.0",
-    "@solana/web3.js": "^1.98.4"
+    "@openzeppelin/contracts": "^5.4.0",
+    "@solana/web3.js": "^1.98.4",
+    "dotenv": "^17.2.3"
   },
   "devDependencies": {
     "@aave/core-v3": "^1.19.3",

--- a/scripts/runArbitrage.ts
+++ b/scripts/runArbitrage.ts
@@ -1,0 +1,64 @@
+import { ethers } from "hardhat";
+import { DEXRegistry } from "../src/dex/core/DEXRegistry";
+
+async function main() {
+  console.log("Starting arbitrage script...");
+
+  // --- 1. Configuration ---
+  const AAVE_POOL_PROVIDER_ADDRESS_BASE = "0x2449373414902241E54854737Bed6cF10a97b274"; // Verified Aave V3 address on Base
+  const DAI_ADDRESS_BASE = "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb";
+  const WETH_ADDRESS_BASE = "0x4200000000000000000000000000000000000006";
+  const LOAN_AMOUNT = ethers.utils.parseUnits("1000", 18); // Borrow 1,000 DAI
+
+  const registry = new DEXRegistry();
+  const uniswapV2 = registry.getDEX("Uniswap V2 on Base");
+  const sushiSwap = registry.getDEX("SushiSwap on Base");
+
+  if (!uniswapV2 || !sushiSwap) {
+    throw new Error("Required DEX configurations not found in the registry.");
+  }
+
+  console.log("Deploying ArbitrageExecutor contract...");
+  const ArbitrageExecutorFactory = await ethers.getContractFactory("ArbitrageExecutor");
+  const arbitrageExecutor = await ArbitrageExecutorFactory.deploy(AAVE_POOL_PROVIDER_ADDRESS_BASE);
+  await arbitrageExecutor.deployed();
+  console.log(`ArbitrageExecutor deployed to: ${arbitrageExecutor.address}`);
+
+  // --- 2. Define Arbitrage Route ---
+  // We will attempt to find a price inefficiency between SushiSwap and Uniswap.
+  // Route: Borrow DAI, swap DAI for WETH on SushiSwap, swap WETH back for DAI on Uniswap V2.
+  const arbitrageParams = {
+    router1: sushiSwap.router,
+    router2: uniswapV2.router,
+    path1: [DAI_ADDRESS_BASE, WETH_ADDRESS_BASE],
+    path2: [WETH_ADDRESS_BASE, DAI_ADDRESS_BASE],
+  };
+
+  console.log("Constructed arbitrage parameters:", arbitrageParams);
+
+  // --- 3. Execute Flash Loan ---
+  console.log(`Requesting flash loan of ${ethers.utils.formatUnits(LOAN_AMOUNT, 18)} DAI...`);
+
+  // Note: This requires the deploying account to have funds to pay for gas.
+  // In a real-world scenario, you would need to set up a proper Hardhat configuration for the Base network.
+  try {
+    const tx = await arbitrageExecutor.requestFlashLoan(
+      DAI_ADDRESS_BASE,
+      LOAN_AMOUNT,
+      arbitrageParams
+    );
+    console.log("Flash loan transaction sent! Hash:", tx.hash);
+    const receipt = await tx.wait();
+    console.log("Transaction confirmed. Gas used:", receipt.gasUsed.toString());
+    console.log("Arbitrage execution complete. Check contract for profit.");
+  } catch (error) {
+    console.error("Arbitrage transaction failed:", error);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/arbitrage/ArbitrageExecutor.sol
+++ b/src/arbitrage/ArbitrageExecutor.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import { IFlashLoanReceiver } from "@aave/core-v3/contracts/flashloan/interfaces/IFlashLoanReceiver.sol";
+import { IPool } from "@aave/core-v3/contracts/interfaces/IPool.sol";
+import { IPoolAddressesProvider } from "@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title IUniswapV2Router
+ * @dev Simplified interface for a Uniswap V2-compatible router.
+ */
+interface IUniswapV2Router {
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function WETH() external pure returns (address);
+}
+
+/**
+ * @title ArbitrageExecutor
+ * @author Copilot
+ * @notice This contract is designed to execute arbitrage opportunities using flash loans from Aave V3.
+ * It borrows assets, performs a series of trades on various DEXs, and repays the loan within a single transaction.
+ */
+contract ArbitrageExecutor is IFlashLoanReceiver {
+    IPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
+    IPool public immutable POOL;
+    address public owner;
+
+    struct ArbitrageParams {
+        address router1;
+        address router2;
+        address[] path1; // e.g., [DAI, WETH]
+        address[] path2; // e.g., [WETH, DAI]
+    }
+
+    error InvalidInitiator(address actual, address expected);
+    error NotOwner(address caller);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) {
+            revert NotOwner(msg.sender);
+        }
+        _;
+    }
+
+    /**
+     * @param provider The address of the Aave V3 PoolAddressesProvider contract.
+     */
+    constructor(address provider) {
+        ADDRESSES_PROVIDER = IPoolAddressesProvider(provider);
+        POOL = IPool(ADDRESSES_PROVIDER.getPool());
+        owner = msg.sender;
+    }
+
+    /**
+     * @notice This function is called by the Aave V3 Pool after the flash loan is initiated.
+     */
+    function executeOperation(
+        address[] calldata assets,
+        uint256[] calldata amounts,
+        uint256[] calldata premiums,
+        address initiator,
+        bytes calldata params
+    ) external override returns (bool) {
+        if (msg.sender != address(POOL)) {
+            revert InvalidInitiator(msg.sender, address(POOL));
+        }
+
+        // Decode the arbitrage parameters
+        ArbitrageParams memory tradeParams = abi.decode(params, (ArbitrageParams));
+
+        // --- CORE ARBITRAGE LOGIC ---
+        address borrowedAsset = assets[0];
+        uint256 borrowedAmount = amounts[0];
+
+        // 1. Approve the first DEX to spend the borrowed asset
+        IERC20(borrowedAsset).approve(tradeParams.router1, borrowedAmount);
+
+        // 2. Execute the first trade (e.g., DAI -> WETH on SushiSwap)
+        IUniswapV2Router(tradeParams.router1).swapExactTokensForTokens(
+            borrowedAmount,
+            0, // We accept any amount out for this example
+            tradeParams.path1,
+            address(this),
+            block.timestamp + 60
+        );
+
+        // 3. Get the balance of the intermediate asset
+        address intermediateAsset = tradeParams.path1[tradeParams.path1.length - 1];
+        uint256 intermediateAmount = IERC20(intermediateAsset).balanceOf(address(this));
+
+        // 4. Approve the second DEX to spend the intermediate asset
+        IERC20(intermediateAsset).approve(tradeParams.router2, intermediateAmount);
+
+        // 5. Execute the second trade (e.g., WETH -> DAI on Uniswap)
+        IUniswapV2Router(tradeParams.router2).swapExactTokensForTokens(
+            intermediateAmount,
+            0, // We accept any amount out
+            tradeParams.path2,
+            address(this),
+            block.timestamp + 60
+        );
+
+        // --- PROFIT VERIFICATION & REPAYMENT ---
+        uint256 finalAmount = IERC20(borrowedAsset).balanceOf(address(this));
+        uint256 amountOwed = borrowedAmount + premiums[0];
+
+        // This is a simplified check. A real implementation would require more robust profit calculation.
+        require(finalAmount >= amountOwed, "Arbitrage failed: Not enough funds to repay loan.");
+
+        // Repay the loan + premium
+        IERC20(borrowedAsset).approve(address(POOL), amountOwed);
+
+        return true;
+    }
+
+    /**
+     * @notice Initiates a flash loan with a specific arbitrage route.
+     * @param asset The address of the asset to borrow.
+     * @param amount The amount of the asset to borrow.
+     * @param params The encoded parameters for the arbitrage trade.
+     */
+    function requestFlashLoan(address asset, uint256 amount, ArbitrageParams calldata params) external onlyOwner {
+        address[] memory assets = new address[](1);
+        assets[0] = asset;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        uint256[] memory modes = new uint256[](1);
+        modes[0] = 0; // No interest rate for flash loans
+
+        bytes memory encodedParams = abi.encode(params);
+
+        POOL.flashLoan(
+            address(this),
+            assets,
+            amounts,
+            modes,
+            address(this), // Initiator is this contract
+            encodedParams,
+            0
+        );
+    }
+
+    /**
+     * @notice Withdraws profits from the contract to the owner.
+     * @param token The address of the token to withdraw.
+     */
+    function withdraw(address token) external onlyOwner {
+        IERC20(token).transfer(owner, IERC20(token).balanceOf(address(this)));
+    }
+
+    receive() external payable {}
+}

--- a/src/dex/core/DEXRegistry.ts
+++ b/src/dex/core/DEXRegistry.ts
@@ -105,6 +105,32 @@ export class DEXRegistry {
 
         // Initialize Raydium
         this.addDEX({
+            name: 'Uniswap V2 on Base',
+            protocol: 'UniswapV2',
+            chainType: 'EVM',
+            network: '8453',
+            router: '0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24',
+            factory: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6',
+            initCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', // This is the generic Uniswap V2 init code hash, may need to be updated for Base
+            priority: 8,
+            liquidityThreshold: BigInt(ethers.utils.parseEther('10000').toString()),
+            gasEstimate: 150000
+        });
+
+        this.addDEX({
+            name: 'SushiSwap on Base',
+            protocol: 'SushiSwap',
+            chainType: 'EVM',
+            network: '8453',
+            router: '0x804b526e5bf4349819fe2db65349d0825870f8ee',
+            factory: '0xc35dadb65012ec5796536bd9864ed8773abc74c4',
+            initCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', // This is the generic SushiSwap init code hash, may need to be updated for Base
+            priority: 9,
+            liquidityThreshold: BigInt(ethers.utils.parseEther('10000').toString()),
+            gasEstimate: 150000
+        });
+
+        this.addDEX({
             name: 'Raydium',
             protocol: 'Raydium',
             chainType: 'Solana',


### PR DESCRIPTION
This commit introduces the necessary components for testing the "Self-Funder" arbitrage mechanism.

- Adds the `ArbitrageExecutor.sol` smart contract, which is designed to perform flash loan-based arbitrage.
- Includes the `runArbitrage.ts` Hardhat script to deploy the contract and execute a test transaction on the Base network.
- Configures Hardhat with a "base" network and sets up environment variable handling for private keys.
- Updates the `DEXRegistry` to include Uniswap V2 and SushiSwap on the Base network.
- Adds necessary dependencies (`@openzeppelin/contracts`, `dotenv`).