### PR TITLE
The validate-env script was failing to connect to the BASE_RPC_URL be…

### DIFF
--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -38,6 +38,19 @@ interface ValidationResult {
   value?: string;
 }
 
+interface NetworkConfig {
+    name: string;
+    chainId: number;
+}
+
+const networkDetails: Record<string, NetworkConfig> = {
+  ETHEREUM_RPC_URL: { name: 'mainnet', chainId: 1 },
+  POLYGON_RPC_URL: { name: 'matic', chainId: 137 },
+  ARBITRUM_RPC_URL: { name: 'arbitrum', chainId: 42161 },
+  BASE_RPC_URL: { name: 'base', chainId: 8453 },
+  OPTIMISM_RPC_URL: { name: 'optimism', chainId: 10 },
+};
+
 const results: ValidationResult[] = [];
 let criticalFailures = 0;
 let warnings = 0;
@@ -82,7 +95,8 @@ async function validateRpcUrl(name: string, category: ValidationResult['category
 
   // Test connection
   try {
-    const provider = new ethers.providers.JsonRpcProvider(url);
+    const network = networkDetails[name];
+    const provider = new ethers.providers.JsonRpcProvider(url, network);
     const blockNumber = await Promise.race([
       provider.getBlockNumber(),
       new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 5000))


### PR DESCRIPTION
…cause ethers.js could not automatically detect the Base network.

This change adds explicit network configurations (name and chainId) for all supported chains, ensuring the JsonRpcProvider connects to the correct network during validation.

This resolves the "could not detect network" error for Base and other L2 networks.