### PR TITLE
feat: Configure Base as primary network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,7 +21,7 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       forking: {
-        url: process.env.ETHEREUM_RPC_URL || "",
+        url: process.env.BASE_RPC_URL || "",
         enabled: process.env.FORKING === "true"
       }
     },
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.WALLET_PRIVATE_KEY ? [process.env.WALLET_PRIVATE_KEY] : []
     },
     mainnet: {
-      url: process.env.ETHEREUM_RPC_URL || "",
+      url: process.env.BASE_RPC_URL || "",
       accounts: process.env.WALLET_PRIVATE_KEY ? [process.env.WALLET_PRIVATE_KEY] : []
     },
     arbitrum: {

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -296,7 +296,7 @@ async function validateEnvironment(): Promise<void> {
   log('🔴 CRITICAL Variables (Bot won\'t run without these):', 'red');
   log('─────────────────────────────────────────────────────────────\n');
   
-  await validateRpcUrl('ETHEREUM_RPC_URL', 'CRITICAL');
+  await validateRpcUrl('BASE_RPC_URL', 'CRITICAL');
   validatePrivateKey();
   validateString('NODE_ENV', 'CRITICAL', 'Runtime environment');
   
@@ -310,9 +310,9 @@ async function validateEnvironment(): Promise<void> {
   log('\n🟡 RECOMMENDED Variables (Multi-chain support):', 'yellow');
   log('─────────────────────────────────────────────────────────────\n');
   
+  await validateRpcUrl('ETHEREUM_RPC_URL', 'RECOMMENDED');
   await validateRpcUrl('POLYGON_RPC_URL', 'RECOMMENDED');
   await validateRpcUrl('ARBITRUM_RPC_URL', 'RECOMMENDED');
-  await validateRpcUrl('BASE_RPC_URL', 'RECOMMENDED');
   await validateRpcUrl('OPTIMISM_RPC_URL', 'RECOMMENDED');
   
   // WebSocket endpoints


### PR DESCRIPTION
This commit updates the project configuration to use the Base network as the primary network for development and mainnet tasks.

The following changes have been made:

- `hardhat.config.ts` has been modified to use `BASE_RPC_URL` for the `hardhat` forking and `mainnet` network configurations.
- `scripts/validate-env.ts` has been updated to reflect this change, making `BASE_RPC_URL` a critical environment variable and `ETHEREUM_RPC_URL` a recommended one.